### PR TITLE
feat: Implement initial game board component and layout

### DIFF
--- a/.ai-agent/memory/activeContext.md
+++ b/.ai-agent/memory/activeContext.md
@@ -14,7 +14,7 @@ Project setup phase is complete. The focus is now shifting towards implementing 
   - Notes: Next.js initialized with TypeScript, Tailwind CSS. Directory structure created. ESLint, Prettier configured. Dependencies added.
 
 - **Task 2**: Define initial component architecture
-  - Status: **Ready to start**
+  - Status: **In Progress**
   - Priority: High
   - Notes: Create core game components (GameBoard, Keyboard), state management hooks, and basic layout.
 
@@ -27,6 +27,7 @@ Project setup phase is complete. The focus is now shifting towards implementing 
 
 ### Code Changes
 
+- 2025-05-02: **Commit `eea3a41` on `feature/implement-gameboard`**: Implemented initial game board component and layout.
 - 2025-05-02: **Commit `b69b441`**: Initialized Next.js project with TypeScript and Tailwind CSS. Restored backup files and merged .gitignore.
 - 2025-05-02: **Commit `30458a2`**: Set up project directory structure (components, lib, hooks, types) with index files.
 - 2025-05-02: **Commit `2eff38b`**: Configured ESLint, Prettier. Added dependencies (LIFF SDK, Vercel KV). Created .env.local.example.
@@ -50,7 +51,7 @@ Project setup phase is complete. The focus is now shifting towards implementing 
 
 ### Immediate Next Tasks
 
-1. Create initial game board component (`src/components/GameBoard.tsx`) and layout adjustments in `src/app/page.tsx`.
+1. Create initial game board component (`src/components/GameBoard.tsx`) and layout adjustments in `src/app/page.tsx`. (Status: In Progress on feature/implement-gameboard)
 2. Implement hiragana keyboard component (`src/components/Keyboard.tsx`).
 3. Develop core game logic module (`src/lib/gameLogic.ts`) including word validation and guess evaluation.
 4. Set up basic game state management using hooks (`src/hooks/useGameState.ts`).
@@ -97,9 +98,9 @@ Project setup phase is complete. The focus is now shifting towards implementing 
 
 ### Current Branch
 
-- Branch: main
+- Branch: feature/implement-gameboard
 - Based on: -
-- Status: Project setup and initial type definitions complete. Ready for core feature development.
+- Status: Initial game board component implemented. Ready for keyboard component.
 
 ### Test Environment
 

--- a/.ai-agent/memory/progress.md
+++ b/.ai-agent/memory/progress.md
@@ -2,6 +2,14 @@
 
 *Last Updated: 2025-05-02*
 
+## Progress Log
+
+- **2025-05-02**:
+  - Created `feature/implement-gameboard` branch.
+  - Implemented the basic `GameBoard.tsx` component with a 6x5 grid layout using Tailwind CSS.
+  - Integrated the `GameBoard` component into the main page (`page.tsx`).
+  - Committed changes (Commit: `eea3a41`).
+
 ## Project Status Summary
 
 **Overall Status**: Initializing

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,102 +1,16 @@
-import Image from "next/image";
+import { GameBoard } from "@/components";
 
 export default function Home() {
   return (
-    <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]">
-      <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol className="list-inside list-decimal text-sm/6 text-center sm:text-left font-[family-name:var(--font-geist-mono)]">
-          <li className="mb-2 tracking-[-.01em]">
-            Get started by editing{" "}
-            <code className="bg-black/[.05] dark:bg-white/[.06] px-1 py-0.5 rounded font-[family-name:var(--font-geist-mono)] font-semibold">
-              src/app/page.tsx
-            </code>
-            .
-          </li>
-          <li className="tracking-[-.01em]">
-            Save and see your changes instantly.
-          </li>
-        </ol>
-
-        <div className="flex gap-4 items-center flex-col sm:flex-row">
-          <a
-            className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:w-auto"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
-            />
-            Deploy now
-          </a>
-          <a
-            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Read our docs
-          </a>
-        </div>
+    <div className="grid grid-rows-[auto_1fr_auto] items-center justify-items-center min-h-screen p-4 pb-8 gap-8 sm:p-8 font-[family-name:var(--font-geist-sans)]">
+      <header className="w-full text-center py-4">
+        <h1 className="text-3xl font-bold">Kanadle</h1>
+      </header>
+      <main className="flex flex-col items-center justify-center w-full">
+        <GameBoard />
       </main>
-      <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
-          />
-          Learn
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to nextjs.org →
-        </a>
+      <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center p-4 text-sm text-gray-500">
+        <p>© 2025 Kanadle Game</p>
       </footer>
     </div>
   );

--- a/src/components/GameBoard.tsx
+++ b/src/components/GameBoard.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+/**
+ * GameBoard component for Kanadle game
+ * Displays a 6x5 grid for the word guessing game
+ */
+const GameBoard: React.FC = () => {
+  // 6行 x 5列のグリッド構造を作成
+  const rows = 6;
+  const cols = 5;
+
+  // 空のグリッドを生成
+  const grid = Array(rows).fill(null).map((_, rowIndex) => (
+    <div key={`row-${rowIndex}`} className="flex mb-2">
+      {Array(cols).fill(null).map((_, colIndex) => (
+        <div
+          key={`cell-${rowIndex}-${colIndex}`}
+          className="w-12 h-12 border-2 border-gray-300 rounded mx-1 flex items-center justify-center text-xl font-bold"
+        >
+          {/* セルの内容はここに表示されます */}
+        </div>
+      ))}
+    </div>
+  ));
+
+  return (
+    <div className="flex flex-col items-center">
+      <h2 className="text-2xl font-bold mb-6">Kanadle</h2>
+      <div className="game-board">
+        {grid}
+      </div>
+    </div>
+  );
+};
+
+export default GameBoard;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -4,4 +4,4 @@
  */
 
 // Example: export { default as Button } from './Button';
-// Example: export { default as GameBoard } from './GameBoard';
+export { default as GameBoard } from './GameBoard';


### PR DESCRIPTION
This PR implements the initial `GameBoard` component and integrates it into the main page layout as outlined in Task 2 of the active context.

**Changes:**

*   Created `src/components/GameBoard.tsx` with a basic 6x5 grid layout using Tailwind CSS.
*   Updated `src/components/index.ts` to export the new component.
*   Modified `src/app/page.tsx` to import and display the `GameBoard` component centrally.
*   Updated memory files (`activeContext.md`, `progress.md`) to reflect the progress.

This sets up the basic UI structure for the Kanadle game. Please review the changes.